### PR TITLE
feat: implement spotify module

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import {
   PomoIcon,
   TaskIcon,
   ThemeIcon,
+  Media,
 } from "@/components";
 import { NavbarItem } from "@/components/navbar/Navbar";
 import { useToggleVisibility } from "./hooks/board/toggle-visibility.hook";
@@ -64,6 +65,7 @@ function App() {
         {visibleModule.pomo && <Pomo />}
         {visibleModule.task && <Task />}
         {visibleModule.note && <Note />}
+        {visibleModule.media && <Media />}
       </Board>
     </Layout>
   );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export { default as Media } from "./media/Media";
 export { default as Navbar } from "./navbar/Navbar";
 export { default as Note } from "./note/Note";
 export { default as Pomo } from "./pomo/Pomo";

--- a/src/components/media/Media.tsx
+++ b/src/components/media/Media.tsx
@@ -1,0 +1,70 @@
+import { FloatModule, ArrowBackIcon, Button, CloseIcon } from "@/components/ui";
+import Spotify from "./Spotify";
+import YouTube from "./Youtube";
+
+import { useMediaActions } from "@/hooks";
+
+export default function Media() {
+  const { closeModule, toggleVisibility, selectedMedia, currentModule } =
+    useMediaActions();
+
+  const mediaComponents: Record<string, JSX.Element> = {
+    Spotify: <Spotify />,
+    YouTube: <YouTube />,
+  };
+  console.log(currentModule);
+  return (
+    <FloatModule bounds="parent" cancel="button,#switch" allowAnyClick>
+      <article className="flex flex-col items-center space-y-3 p-4 bg-primary rounded-lg w-[22rem] shadow-md select-none">
+        <header className="w-full">
+          <ul className="flex justify-between">
+            <li className="flex items-center">
+              <Button
+                variant={"ghost"}
+                onClick={() => toggleVisibility("Media")}
+                disabled={selectedMedia.Media}
+              >
+                {!selectedMedia.Media && <ArrowBackIcon />}
+              </Button>
+            </li>
+            <li className="flex items-center">
+              <h2 className="text-lg font-bold text-primary">
+                {currentModule}
+              </h2>
+            </li>
+            <li className="flex items-center">
+              <Button variant={"ghost"} onClick={() => closeModule("media")}>
+                <CloseIcon />
+              </Button>
+            </li>
+          </ul>
+        </header>
+
+        <div className="flex flex-col items-center justify-center space-y-4 w-full">
+          <div className="w-full">
+            {selectedMedia.Media ? (
+              <ul className="flex text-primary justify-center gap-4">
+                <li>
+                  <Button onClick={() => toggleVisibility("YouTube")}>
+                    YouTube
+                  </Button>
+                </li>
+                <li>
+                  <Button onClick={() => toggleVisibility("Spotify")}>
+                    Spotify
+                  </Button>
+                </li>
+              </ul>
+            ) : (
+              <div className="w-full text-center">
+                <h2 className="text-lg font-semibold text-primary">
+                  {mediaComponents[currentModule] || <p>No media selected</p>}
+                </h2>
+              </div>
+            )}
+          </div>
+        </div>
+      </article>
+    </FloatModule>
+  );
+}

--- a/src/components/media/Spotify.tsx
+++ b/src/components/media/Spotify.tsx
@@ -1,0 +1,12 @@
+function Spotify() {
+  return (
+    <div className="p-4 bg-gray-100 rounded-lg shadow-md">
+      <h1 className="text-2xl font-bold text-green-600 mb-4">
+        Spotify Component
+      </h1>
+      <p className="text-gray-700">Bienvenido al componente de Spotify.</p>
+    </div>
+  );
+}
+
+export default Spotify;

--- a/src/components/media/Youtube.tsx
+++ b/src/components/media/Youtube.tsx
@@ -1,0 +1,12 @@
+function YouTube() {
+  return (
+    <div className="p-4 bg-gray-100 rounded-lg shadow-md">
+      <h1 className="text-2xl font-bold text-red-600 mb-4">
+        YouTube Component
+      </h1>
+      <p className="text-gray-700">Bienvenido al componente de YouTube.</p>
+    </div>
+  );
+}
+
+export default YouTube;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./pomo";
 export * from "./board";
+export * from "./media";

--- a/src/hooks/media/index.ts
+++ b/src/hooks/media/index.ts
@@ -1,0 +1,1 @@
+export * from "./use-actions.hooks";

--- a/src/hooks/media/use-actions.hooks.ts
+++ b/src/hooks/media/use-actions.hooks.ts
@@ -1,0 +1,16 @@
+import { useBoardStore, useMediaStore } from "@/stores";
+
+export function useMediaActions() {
+  const toggleVisibility = useMediaStore(state => state.toggleVisibility);
+  const selectedMedia = useMediaStore(state => state.visibleModules);
+  const currentModule = useMediaStore(state => state.currentModule);
+
+  const closeModule = useBoardStore(state => state.toggleVisibility);
+
+  return {
+    closeModule,
+    toggleVisibility,
+    selectedMedia,
+    currentModule,
+  };
+}

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,4 +1,5 @@
 export * from "./board.store";
+export * from "./media.store";
 export * from "./note.store";
 export * from "./pomo.store";
 export * from "./task.store";

--- a/src/stores/media.store.ts
+++ b/src/stores/media.store.ts
@@ -1,0 +1,42 @@
+import { MediaId } from "@/types/media";
+import { StateCreator, create } from "zustand";
+import { persist } from "zustand/middleware";
+import { immer } from "zustand/middleware/immer";
+
+interface MediaState {
+  visibleModules: Record<MediaId, boolean>;
+  currentModule: MediaId;
+  toggleVisibility: (moduleId: MediaId) => void;
+}
+
+const storeApi: StateCreator<MediaState, [["zustand/immer", never]]> = set => ({
+  visibleModules: {
+    Media: true,
+    Spotify: false,
+    YouTube: false,
+  },
+  currentModule: "Media",
+
+  toggleVisibility: (moduleId: MediaId) => {
+    set(state => {
+      state.visibleModules[state.currentModule] = false;
+
+      state.visibleModules[moduleId] = true;
+      state.currentModule = moduleId;
+    });
+  },
+});
+
+export const useMediaStore = create<MediaState>()(
+  persist(immer(storeApi), {
+    name: "media-store",
+    partialize: state => ({
+      currentModule: state.currentModule,
+      visibleModules: {
+        Media: state.visibleModules.Media,
+        Spotify: state.visibleModules.Spotify,
+        YouTube: state.visibleModules.YouTube,
+      },
+    }),
+  })
+);

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -1,0 +1,1 @@
+export type MediaId = "YouTube" | "Spotify" | "Media";


### PR DESCRIPTION
reorganize media components

- Moved Spotify and YouTube components to the new media directory.
- Updated import paths in the Media component.
- Simplified media component mapping for easier scalability.